### PR TITLE
Assume the environment is set correctly before server.launch is roslaunched

### DIFF
--- a/hamster_server_launch/launch/server.launch
+++ b/hamster_server_launch/launch/server.launch
@@ -1,8 +1,4 @@
 <launch>
-    <arg name="server_ip" default="10.0.2.152" />
-    
-    <env name="ROS_IP" value="$(arg server_ip)" />
-    <env name="ROS_MASTER_URI" value="http://$(arg server_ip):11311" />
     
     <param name="/mrm/robots_count" value="2" />
 


### PR DESCRIPTION
In my opinion, having the ROS_MASTER_URI be hard-coded with a default value that's likely to be invalid for a given ROS system is likely to cause issues for more users than trusting whatever value may or may not be set in the shell environment.

The error says the master cannot be reached, even if the user has the URI set correctly in the traditional ROS fashion, in their environment.

Hypothetically, a less experienced user might see the same error, google for how to fix such errors, learn they need to set ROS_MASTER_URI in their environment, and try again... only to see the same error about the same incorrect ROS_MASTER_URI (that they would have no reason to assume might be being set in the launch file). I imagine that, for the aforementioned hypothetical user, this would likely make the steep ROS learning curve even more so.